### PR TITLE
Change "Iterable" interface to "Traversable"

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Provides a simple interface to work with Unicode strings in upcoming PHP7.
 /** 
 * @property int $length The number of unicode code points (read-only)
 **/
-abstract class UString implements Traversable {
+class UString implements Traversable {
     /**
     * Shall create a UString with the given value and codepage.
     * If no codepage is provided, the default codepage will be used.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Provides a simple interface to work with Unicode strings in upcoming PHP7.
 /** 
 * @property int $length The number of unicode code points (read-only)
 **/
-abstract class UString implements Iterable {
+abstract class UString implements Traversable {
     /**
     * Shall create a UString with the given value and codepage.
     * If no codepage is provided, the default codepage will be used.


### PR DESCRIPTION
The interface originally implemented in the UString class documented in the `README.md` file was an invalid "Iterable" interface.

PHP has no "Iterable" interface, however a ["Traversable"](http://php.net/manual/en/class.traversable.php) interface does exist (and seems to have been the intended choice.
